### PR TITLE
Add CVE scan pipeline as scheduled nightly

### DIFF
--- a/.github/containerscan/allowedlist.yaml
+++ b/.github/containerscan/allowedlist.yaml
@@ -1,0 +1,2 @@
+general:
+  vulnerabilities: [] # List of excluded CVEs (e.g: CVE-2021-3711)

--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -1,0 +1,22 @@
+name: "CVE Scan"
+on:
+  workflow_dispatch: { }
+  schedule:
+    - cron: '*/5 0 * * *'
+jobs:
+  scan-images:
+    name: Scan latest public image
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image: [ docker-asciidoctor ]
+        tag: [ latest ]
+    steps:
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'docker.io/asciidoctor/${{ matrix.image }}:${{ matrix.tag }}'
+          severity: 'CRITICAL,HIGH'
+          format: 'table'
+          # we can set to 0 to avoid breaking the pipeline
+          exit-code: '1'


### PR DESCRIPTION
The new 'CVE scan' pipeline scans the latest published
image for high & critical vulnerabilities.